### PR TITLE
backend.py prevent stack trace when not given overlay

### DIFF
--- a/g_sorcery/backend.py
+++ b/g_sorcery/backend.py
@@ -617,6 +617,8 @@ class Backend(object):
             Exit status.
         """
         args = self.parser.parse_args(args)
+        if not args.overlay:
+            self.parser.error("No overlay specified")
         info_f = FileJSON(os.path.join(args.overlay, self.sorcery_dir),
                           "info.json", ["repositories"])
         self.info = info_f.read()


### PR DESCRIPTION
Prevent a python stack trace in `backend.py` that can happen when invoking `gs-pypi` without arguments, for example.

### Before
```python
# gs-pypi
Traceback (most recent call last):
  File "/usr/lib/python-exec/python3.4/g-sorcery", line 18, in <module>
    sys.exit(g_sorcery.main())
  File "/usr/lib/python3.4/site-packages/g_sorcery/g_sorcery.py", line 68, in main
    return backend.instance(sys.argv[2:], config, global_config)
  File "/usr/lib/python3.4/site-packages/g_sorcery/backend.py", line 620, in __call__
    info_f = FileJSON(os.path.join(args.overlay, self.sorcery_dir),
  File "/usr/lib/python3.4/posixpath.py", line 82, in join
    path += b
TypeError: unsupported operand type(s) for +=: 'NoneType' and 'str'
```

### After
```python
# gs-pypi
usage: g-sorcery [-h] [-o OVERLAY] [-r REPOSITORY]
                 {sync,list,generate,generate-tree,install} ...
g-sorcery: error: No overlay specified
```